### PR TITLE
Expand/evaluate ENV variables in master_heart_attack spec

### DIFF
--- a/task_schedule.pl
+++ b/task_schedule.pl
@@ -76,7 +76,7 @@ help(2) if ($opt{help});
 ##***************************************************************************
 our $safe = new Safe;		# Make a safe container for doing evals
 $safe->share('%ENV');
-foreach (qw(data_dir bin_dir log_dir)) {
+foreach (qw(data_dir bin_dir log_dir master_heart_attack)) {
     $opt{$_} = defined $opt{$_} ? $safe->reval(qq/"$opt{$_}"/) : ".";
     dbg "$_=$opt{$_}";
 }


### PR DESCRIPTION
The docs already implied that this was done with the $ENV{SKA_DATA}
example:

master_heart_attack $ENV{SKA_DATA}/task_schedule/master_heart_attack
