### PR TITLE
Add machine process status (sorted by mem, CPU) to error outputs

### DIFF
--- a/task_schedule.pl
+++ b/task_schedule.pl
@@ -275,7 +275,8 @@ sub get_machine_status {
 # sorted by memory and CPU.
 #
 ##***************************************************************************
-    my $out = "\n******** Sorted by resident memory (RSS) ********\n";
+    my $out = "\n******** Running on $ENV{HOSTNAME} as $ENV{USER} ********\n";
+    $out .= "\n******** Sorted by resident memory (RSS) ********\n";
     my %par = (timeout => 5, out => \$out);
     run_tool('/bin/ps -A -F --sort=-rss | /usr/bin/head -20', \%par);
     $out .= "\n******** Sorted by CPU ********\n";


### PR DESCRIPTION
@jeanconn - this is a little scary putting something new deep into task_schedule, but at least we have some tests that seem to still work.  See emails (separate) for examples.
