### PR TITLE
Add code to stop task schedule after N days

### DIFF
--- a/task_schedule.pl
+++ b/task_schedule.pl
@@ -267,12 +267,11 @@ while (-r $opt{heartbeat}) {
     ##  (minus a minute)
     ##*****************************************************
     my $curr_time = time();
-    my $run_time = $curr_time - $start_time;
-    if ($run_time > (86400 * $opt{max_persistent_days} - 60)){
-        my $days = $run_time / 86400.0;
+    my $run_days = ($curr_time - $start_time + 60) / 86400.0;
+    if ($run_days > $opt{max_persistent_days}) {
         my $message = sprintf(
                               "Ending this task_schedule; job %.2f days old",
-                              $days);
+                              $run_days);
         dbg "$message";
         exit(0);
     }


### PR DESCRIPTION
This is meant to give a fresh process after a persistent task_schedule
has been running for N days.  N is 5 by default and set by the
max_persistent_days cfg option.