### PR TITLE
Updates for Perl 5.26.2 and skare3 noarch env

### DIFF
--- a/task_schedule.pl
+++ b/task_schedule.pl
@@ -11,7 +11,7 @@ use warnings;
 use strict;
 use File::Basename;
 use Getopt::Long;
-use Config::General;
+use Config::General qw( ParseConfig );
 use Sys::Hostname ();
 use Data::Dumper;
 use Safe;

--- a/task_schedule.pl
+++ b/task_schedule.pl
@@ -19,7 +19,6 @@ use Cwd;
 use Schedule::Cron;
 use IO::File;
 use subs qw(dbg);
-use CXC::Envs::Flight;
 use POSIX qw(strftime);
 use IO::All;
 use Mail::Send;
@@ -31,7 +30,7 @@ use Ska::Process qw(send_mail);
 ##***************************************************************************
 
 $| = 1;
-%ENV = CXC::Envs::Flight::env('ska'); # Adds Ska env to existing ENV
+
 
 ##***************************************************************************
 ##   Get config and cmd line options

--- a/task_schedule.pl
+++ b/task_schedule.pl
@@ -20,6 +20,7 @@ use Schedule::Cron;
 use IO::File;
 use subs qw(dbg);
 use POSIX qw(strftime);
+use File::Temp;
 use IO::All;
 use Mail::Send;
 use Ska::Process qw(send_mail);
@@ -321,7 +322,7 @@ sub check_outputs {
 ##***************************************************************************
     my $cronjob = shift;
 
-    my $watch_config = io(POSIX::tmpnam);
+    my $watch_config = io(File::Temp::tmpnam);
     my $log_dir = dirname($cronjob->{log});
     my $config .= Config::General->new()->save_string({ check => $cronjob->{check},
 							alert => $opt{alert},


### PR DESCRIPTION
Updates for Perl 5.26.2 and skare3 noarch env .

This gets rid of the call to CXC::Envs::Flight, explicitly imports ParseConfig from Config::General, and uses File::Temp::tmpnam instead of POSIX::tmpnam (deprecated/no-longer-implemented).

These changes should all be back compatible, but I also figured we would not be installing updated task_schedule in Python 2 ska (so not explicitly tested).  I also don't know if you want to merge this branch (skare3) or just use it for future updates.