### PR TITLE
Initial steps to modernizing task_schedule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/data
+/bin
+/dat
+/doc

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,11 @@
 # Set the task name
 TASK = task_schedule
 
-# Uncomment the correct choice indicating either SKA or TST flight environment
-FLIGHT_ENV = SKA
-
 # Set the names of all files that get installed
 BIN = task_schedule3.pl
-include /proj/sot/ska/include/Makefile.FLIGHT
 
 # Define outside data and bin dependencies required for testing,
-# i.e. all tools and data required by the task which are NOT 
+# i.e. all tools and data required by the task which are NOT
 # created by or internal to the task itself.  These will be copied
 # first from the local test directory t/ and if not found from the
 # ROOT_FLIGHT area.
@@ -22,56 +18,67 @@ TEST_DEP = data/basic/basic.config \
 	bin/watch_cron_logs.pl \
 	bin/exception.py
 
+TEST_SKA = $(PWD)/test_ska
+
+# Define installation PREFIX as the sys.prefix of python in the PATH.
+PREFIX = $(shell python -c 'import sys; print(sys.prefix)')
+
 # To 'test', first check that the INSTALL root is not the same as the FLIGHT
 # root with 'check_install' (defined in Makefile.FLIGHT).  Typically this means
 # doing 'setenv TST .'.  Then copy any outside data or bin dependencies into local
 # directory via dependency rules defined in Makefile.FLIGHT.  Finally install
-# the task, typically in '.'. 
+# the task, typically in '.'.
 
 test: test_basic test_exception test_basic_full test_fail test_send_mail test_send_mail_quiet
 
-test_basic: check_install $(TEST_DEP) install
-	rm -f $(INSTALL)/data/basic/task_sched_heartbeat
-	rm -f $(INSTALL)/data/basic/task_sched_heart_attack
-	rm -f $(INSTALL)/data/basic/task_sched_disable_alerts
-	perl $(INSTALL_BIN)/task_schedule3.pl -alert $(USER) -config $(INSTALL)/data/basic/basic.config -fast 6 -no-email -loud
+show_prefix:
+	echo $(PREFIX)
 
-test_exception:check_install $(TEST_DEP) install
-	rm -f $(INSTALL)/data/exception/task_sched_heartbeat
-	rm -f $(INSTALL)/data/exception/task_sched_heart_attack
-	rm -f $(INSTALL)/data/exception/task_sched_disable_alerts
-	perl $(INSTALL_BIN)/task_schedule3.pl -alert $(USER) -config $(INSTALL)/data/exception/exception.config -fast 6 -no-email -loud
+test_basic:
+	rm -rf $(TEST_SKA)
+	rsync -av t/ $(TEST_SKA)/
+	env SKA=$(TEST_SKA) ./task_schedule3.pl -alert $(USER) \
+ 		-config $(TEST_SKA)/data/basic/basic.config -fast 6 -no-email -loud
 
-test_basic_full: check_install $(TEST_DEP) install
-	rm -f $(INSTALL)/data/basic/task_sched_heartbeat
-	rm -f $(INSTALL)/data/basic/task_sched_heart_attack
-	rm -f $(INSTALL)/data/basic/task_sched_disable_alerts
-	perl $(INSTALL_BIN)/task_schedule3.pl -alert $(USER) -config $(INSTALL)/data/basic/basic.config -loud
+test_exception:
+	rm -rf $(TEST_SKA)
+	rsync -av t/ $(TEST_SKA)/
+	env SKA=$(TEST_SKA) ./task_schedule3.pl -alert $(USER) \
+		-config $(TEST_SKA)/data/exception/exception.config -fast 6 -no-email -loud
 
-test_fail: check_install $(TEST_DEP) install 
-	rm -f $(INSTALL)/data/fail/task_sched_heartbeat
-	rm -f $(INSTALL)/data/fail/task_sched_heart_attack
-	rm -f $(INSTALL)/data/fail/task_sched_disable_alerts
-	perl $(INSTALL_BIN)/task_schedule3.pl -alert $(USER) -config $(INSTALL)/data/fail/fail.config -fast 20 -loud
+test_basic_full:
+	rm -rf $(TEST_SKA)
+	rsync -av t/ $(TEST_SKA)/
+	env SKA=$(TEST_SKA) ./task_schedule3.pl -alert $(USER) \
+		-config $(TEST_SKA)/data/basic/basic.config -loud
 
-test_send_mail: check_install $(TEST_DEP) install 
-	rm -f $(INSTALL)/data/send_mail/task_sched_heartbeat
-	rm -f $(INSTALL)/data/send_mail/task_sched_heart_attack
-	rm -f $(INSTALL)/data/send_mail/task_sched_disable_alerts
-	perl $(INSTALL_BIN)/task_schedule3.pl -alert $(USER) -config $(INSTALL)/data/send_mail/send_mail.config -fast 5 -loud
+test_fail:
+	rm -rf $(TEST_SKA)
+	rsync -av t/ $(TEST_SKA)/
+	env SKA=$(TEST_SKA) ./task_schedule3.pl -alert $(USER) \
+		-config $(TEST_SKA)/data/fail/fail.config -fast 20 -loud
 
-test_send_mail_quiet: check_install $(TEST_DEP) install 
-	rm -f $(INSTALL)/data/send_mail/task_sched_heartbeat
-	rm -f $(INSTALL)/data/send_mail/task_sched_heart_attack
-	rm -f $(INSTALL)/data/send_mail/task_sched_disable_alerts
-	perl $(INSTALL_BIN)/task_schedule3.pl -alert $(USER) -config $(INSTALL)/data/send_mail/send_mail.config -fast 5 
+test_send_mail:
+	rm -rf $(TEST_SKA)
+	rsync -av t/ $(TEST_SKA)/
+	env SKA=$(TEST_SKA) ./task_schedule3.pl -alert $(USER) \
+		-config $(TEST_SKA)/data/send_mail/send_mail.config -fast 5 -loud
+
+test_send_mail_quiet:
+	rm -rf $(TEST_SKA)
+	rsync -av t/ $(TEST_SKA)/
+	env SKA=$(TEST_SKA) ./task_schedule3.pl -alert $(USER) \
+		-config $(TEST_SKA)/data/send_mail/send_mail.config -fast 5
 
 install:
-	mkdir -p $(INSTALL_BIN); rsync --times --cvs-exclude $(BIN) $(INSTALL_BIN)/
-	mkdir -p $(INSTALL_DOC)
-	pod2html task_schedule3.pl > $(INSTALL_DOC)/index.html
+	mkdir -p $(PREFIX)/bin
+	rsync --times --cvs-exclude $(BIN) $(PREFIX)/bin/
+
+install_doc:
+	mkdir -p $(SKA)/doc/$(TASK)
+	pod2html task_schedule3.pl > $(SKA)/doc/$(TASK)/index.html
 	rm -f pod2htm?.tmp
 
 clean:
-	rm -r bin data doc
+	rm -r $(TEST_SKA)
 

--- a/t/data/basic/basic.config
+++ b/t/data/basic/basic.config
@@ -3,14 +3,14 @@
 subject      Basic tests               # subject of email
 timeout      1000                    # Default tool timeout
 heartbeat_timeout 120                # Maximum age of heartbeat file (seconds)
-iterations   5
+iterations   3
 
 # Data files and directories.  The *_dir vars can have $ENV{} vars which
 # get interpolated.  (Note lack of task name after TST_DATA because this is just for test).
 
-data_dir     $ENV{SKA_DATA}/basic          # Data file directory
-log_dir      $ENV{SKA_DATA}/basic/logs     # Log file directory
-bin_dir      $ENV{SKA_BIN}           # Bin dir (optional, see task def'n)
+data_dir     $ENV{SKA}/data/basic          # Data file directory
+log_dir      $ENV{SKA}/data/basic/logs     # Log file directory
+bin_dir      $ENV{SKA}/bin           # Bin dir (optional, see task def'n)
 
 # Email addresses that receive an alert if there was a severe error in
 # running jobs (i.e. couldn't start jobs or couldn't open log file).
@@ -20,7 +20,7 @@ bin_dir      $ENV{SKA_BIN}           # Bin dir (optional, see task def'n)
 
 # Define task parameters
 #  cron: Job repetition specification ala crontab
-#  exec: Name of executable.  Can have $ENV{} vars which get interpolated.  
+#  exec: Name of executable.  Can have $ENV{} vars which get interpolated.
 #        If bin_dir is defined then bin_dir is prepended to non-absolute exec names.
 #  log: Name of log.  Can have $ENV{} vars which get interpolated.
 #        If log is set to '' then no log file will be created
@@ -37,7 +37,7 @@ bin_dir      $ENV{SKA_BIN}           # Bin dir (optional, see task def'n)
       cron       * * * * *
       check_cron = 0-59/2 * * * *
       exec 1 : task1.pl 1
-      exec 1 : $ENV{SKA_BIN}/task1.pl 2
+      exec 1 : $ENV{SKA}/bin/task1.pl 2
       timeout 100
       context 1
       <checkk>

--- a/t/data/exception/exception.config
+++ b/t/data/exception/exception.config
@@ -8,9 +8,9 @@ iterations   1
 # Data files and directories.  The *_dir vars can have $ENV{} vars which
 # get interpolated.  (Note lack of task name after TST_DATA because this is just for test).
 
-data_dir     $ENV{SKA_DATA}/exception          # Data file directory
-log_dir      $ENV{SKA_DATA}/exception/logs     # Log file directory
-bin_dir      $ENV{SKA_BIN}           # Bin dir (optional, see task def'n)
+data_dir     $ENV{SKA}/data/exception          # Data file directory
+log_dir      $ENV{SKA}/data/exception/logs     # Log file directory
+bin_dir      $ENV{SKA}/bin           # Bin dir (optional, see task def'n)
 
 # Email addresses that receive an alert if there was a severe error in
 # running jobs (i.e. couldn't start jobs or couldn't open log file).
@@ -20,7 +20,7 @@ bin_dir      $ENV{SKA_BIN}           # Bin dir (optional, see task def'n)
 
 # Define task parameters
 #  cron: Job repetition specification ala crontab
-#  exec: Name of executable.  Can have $ENV{} vars which get interpolated.  
+#  exec: Name of executable.  Can have $ENV{} vars which get interpolated.
 #        If bin_dir is defined then bin_dir is prepended to non-absolute exec names.
 #  log: Name of log.  Can have $ENV{} vars which get interpolated.
 #        If log is set to '' then no log file will be created
@@ -37,7 +37,7 @@ bin_dir      $ENV{SKA_BIN}           # Bin dir (optional, see task def'n)
       cron       * * * * *
       check_cron = * * * * *
       exec task1.pl 1
-      exec python $ENV{SKA_BIN}/exception.py
+      exec $ENV{SKA}/bin/exception.py
       timeout 100
       context 1
       <check>

--- a/t/data/fail/fail.config
+++ b/t/data/fail/fail.config
@@ -9,9 +9,9 @@ heartbeat_timeout 120                # Maximum age of heartbeat file (seconds)
 # Data files and directories.  The *_dir vars can have $ENV{} vars which
 # get interpolated.  (Note lack of task name after TST_DATA because this is just for test).
 
-data_dir     $ENV{SKA_DATA}/fail          # Data file directory
-log_dir      $ENV{SKA_DATA}/fail/logs     # Log file directory
-bin_dir      $ENV{SKA_BIN}           # Bin dir (optional, see task def'n)
+data_dir     $ENV{SKA}/data/fail          # Data file directory
+log_dir      $ENV{SKA}/data/fail/logs     # Log file directory
+bin_dir      $ENV{SKA}/bin           # Bin dir (optional, see task def'n)
 
 # Email addresses that receive an alert if there was a severe error in
 # running jobs (i.e. couldn't start jobs or couldn't open log file).
@@ -21,7 +21,7 @@ bin_dir      $ENV{SKA_BIN}           # Bin dir (optional, see task def'n)
 
 # Define task parameters
 #  cron: Job repetition specification ala crontab
-#  exec: Name of executable.  Can have $ENV{} vars which get interpolated.  
+#  exec: Name of executable.  Can have $ENV{} vars which get interpolated.
 #        If bin_dir is defined then bin_dir is prepended to non-absolute exec names.
 #  log: Name of log.  Can have $ENV{} vars which get interpolated.
 #        If log is set to '' then no log file will be created
@@ -35,25 +35,25 @@ bin_dir      $ENV{SKA_BIN}           # Bin dir (optional, see task def'n)
         exec task1.pll 20
         log  task1_nonstandard.log
   </task>
-  
+
   # Task that times out
   <task task2>
         cron * * * * *
         exec task2.pl 10
         timeout 5
   </task>
-  
+
   # Can't write log file
  <task task3>
        cron * * * * *
        exec task1.pl 10
        log /cant/write/to/this/logfile
  </task>
- 
+
  # Executable that returns non-zero status
  <task task4>
        cron * * * * *
        exec /bin/ls doesntexist
  </task>
- 
- 
+
+

--- a/t/data/send_mail/send_mail.config
+++ b/t/data/send_mail/send_mail.config
@@ -18,9 +18,9 @@ NOTIFY
 # Data files and directories.  The *_dir vars can have $ENV{} vars which
 # get interpolated.  (Note lack of task name after TST_DATA because this is just for test).
 
-data_dir     $ENV{SKA_DATA}/send_mail          # Data file directory
-log_dir      $ENV{SKA_DATA}/send_mail/logs     # Log file directory
-bin_dir      $ENV{SKA_BIN}                     # Bin dir ($ENV{SKA_BIN} is typical)
+data_dir     $ENV{SKA}/data/send_mail          # Data file directory
+log_dir      $ENV{SKA}/data/send_mail/logs     # Log file directory
+bin_dir      $ENV{SKA}/bin                     # Bin dir ($ENV{SKA_BIN} is typical)
 
 # Email addresses that receive notification that the task ran
 

--- a/t/data/test.config
+++ b/t/data/test.config
@@ -8,9 +8,9 @@ heartbeat_timeout 120                # Maximum age of heartbeat file (seconds)
 # Data files and directories.  The *_dir vars can have $ENV{} vars which
 # get interpolated.  (Note lack of task name after TST_DATA because this is just for test).
 
-data_dir     $ENV{SKA_DATA}          # Data file directory
-log_dir      $ENV{SKA_DATA}/Logs     # Log file directory
-bin_dir      $ENV{SKA_BIN}           # Bin dir (optional, see task def'n)
+data_dir     $ENV{SKA}/data          # Data file directory
+log_dir      $ENV{SKA}/data/Logs     # Log file directory
+bin_dir      $ENV{SKA}/bin           # Bin dir (optional, see task def'n)
 master_log   Master.log              # Composite master log (created in log_dir)
 heartbeat    heartbeat		     # File to ensure sched. running (in data_dir)
 
@@ -57,7 +57,7 @@ heartbeat    heartbeat		     # File to ensure sched. running (in data_dir)
 <task task3>
       cron * * * * *
       exec task1.pl 1
-      exec 2 : $ENV{SKA_BIN}/task1.pl 2
+      exec 2 : $ENV{SKA}/bin/task1.pl 2
       exec 4 : task1.pl 3
       timeout 100
       context 1


### PR DESCRIPTION
Cuts the cruft that no longer applies and makes this work on a standalone MacOS platform.

Substantive code changes are:
- Ensure that the `SKA_ARCH_OS` env var is always defined, even in a (non-production) conda env.
- If a non-absolute executable is specified as a command, then check if it exists in `bin_dir`.  ONLY if it exists and is executable then prepend `bin_dir` to the executable path.  This was previously done regardless of whether the executable was found in `bin_dir`.  This new logic allows specifying an executable that is in the global search `PATH`.  This is more common now with the use of entry point scripts, e.g. `cheta_sync` or `kadi_update_cmds`.

This takes a different approach to unit testing and just installs locally in a fixed directory, then overrides `SKA`.  For these tests `SKA` is the root for both `data` and `bin`.

## Testing

### Created a testing Ska3 environment on linux and MacOS
```
conda create -n ska3-kady-task -c $ska3conda -c $ska3conda/core-pkg-repo ska3-flight ska3-perl
source activate ska3-kady-task
# Note that the kadi => kady machine migration has gotten into my fingers
# and so the env name is a little misleading.

conda uninstall --force ska3-flight ska3-core ska3-perl
conda uninstall --force kadi task_schedule watch_cron_logs

# Then from respective modernize branches install task_schedule and
# watch_cron_logs with `make install`.
# Install kadi `py3-cmds-task` branch (version 4.19) with pip install.
# Also make Ska $CONDA_PREFIX/data/ directory with kadi and cmd_states dirs.
# kadi is new but cmd_states is a link.
```

### task_schedule self-test

Then from the task_schedule git repo, each of the following gave expected results
```
make test_basic
make test_exception
make test_basic_full
make test_fail
make test_send_mail  # Does not send mail on MacOS
make test_send_mail_quiet  # Does not send mail on MacOS
```
Note that `make test` had problems because it seemed to start the `exception` test before the `basic` test was done since this forks off processes.

### Test with kadi 4.19 (`py3-cmds-task` branch) on linux and MacOS
```
skare task_schedule3.pl -config kadi/task_schedule_cmds.cfg
```
Expected results:
- Saw process running (the cfg file was locally modified to have `loud=1`)
- Saw expected output in the log file in `${CONDA_PREFIX}/data/kadi/logs/kadi_cmds.log`

