### PR TITLE
Fix bug dropping command args for executable in bin_dir

### DIFF
--- a/task_schedule3.pl
+++ b/task_schedule3.pl
@@ -112,13 +112,13 @@ while (my ($name, $task) = each %{$opt{task}}) {
 
 	# If (after interpolation) the exec isn't an absolute path
 	# and there is a bin_dir defined and there is an executable
-    # at bin_dir/cmd, then prepend that to path
+        # at bin_dir/cmd, then prepend that to path
 	if (not $_->{cmd} =~ m|\A \s* /|x and $opt{bin_dir}) {
-        my ($bin_dir_cmd, @cmd_args) = split(" ", "$opt{bin_dir}/$_->{cmd}");
-	    if (-e $bin_dir_cmd and -x $bin_dir_cmd) {
-            $_->{cmd} = $bin_dir_cmd;
+            my ($bin_dir_cmd, @cmd_args) = split(" ", "$opt{bin_dir}/$_->{cmd}");
+            if (-e $bin_dir_cmd and -x $bin_dir_cmd) {
+                $_->{cmd} = $bin_dir_cmd . " " . join(" ", @cmd_args);
+            }
         }
-    }
     }
 
     # Do the same for the log file, except that a value of undef


### PR DESCRIPTION
Noted in processing for twiki-wg after skare3 2020.1 deploy.

## Testing

- [x] Passes tests in Makefile
- [x] Ran with in flight for `twiki-wg` and had a successful run with expected outputs.

### Twiki-wg outputs
```
ska3-aca-kady% 16:37:29 [                  main  457]  Running '/bin/rm -f /proj/sot/ska3/flight/data/twiki-wg/task_sched_disable_alerts' 0 1
16:37:29 [                  main  457]  Running '/proj/sot/ska3/flight/share/twiki-wg/make_wg_index.py --data-dir /proj/sot/ska3/flight/data/twiki-wg --working-group-web=Aspect --meeting-root=StarWorkingGroupMeeting --meeting-index-page=StarWorkingGroup --index-file=ssawg_index.html' 0 1
16:37:29 [                  main  470]  enable_alerts output:
16:37:29 [                  main  471]  
16:37:29 [   ./task_schedule3.pl  272]  
16:38:01 [                  main  470]  twiki-wg output:
16:38:01 [                  main  471]  Reading https://occweb.cfa.harvard.edu/twiki/bin/view/Aspect/StarWorkingGroup twiki page
                                        Reading https://occweb.cfa.harvard.edu/twiki/bin/view/Aspect/StarWorkingGroupMeeting2020x01x15 twiki page
                                        Writing to /proj/sot/ska3/flight/data/twiki-wg/ssawg_index.html
                                        Reading https://occweb.cfa.harvard.edu/twiki/bin/view/Aspect/StarWorkingGroupMeeting2020x01x29 twiki page
                                        
16:38:01 [                  main  457]  Running '/proj/sot/ska3/flight/share/twiki-wg/make_wg_index.py --data-dir /proj/sot/ska3/flight/data/twiki-wg --working-group-web=MPCWG --meeting-root=MeetingNotes --meeting-index-page=MeetingNotesArchive --index-file=mpcwg_index.html' 0 1
16:38:22 [                  main  470]  twiki-wg output:
16:38:22 [                  main  471]  Reading https://occweb.cfa.harvard.edu/twiki/bin/view/MPCWG/MeetingNotesArchive twiki page
                                        Reading https://occweb.cfa.harvard.edu/twiki/bin/view/MPCWG/MeetingNotes2019x12x05 twiki page
                                        Writing to /proj/sot/ska3/flight/data/twiki-wg/mpcwg_index.html
                                        Reading https://occweb.cfa.harvard.edu/twiki/bin/view/MPCWG/MeetingNotes2020x01x16 twiki page
                                        
16:38:22 [                  main  457]  Running '/proj/sot/ska3/flight/share/twiki-wg/make_wg_index.py --data-dir /proj/sot/ska3/flight/data/twiki-wg --working-group-web=ThermalWG --meeting-root=MeetingNotes --meeting-index-page=MeetingNotes --index-file=twg_index.html' 0 1
16:38:30 [                  main  470]  twiki-wg output:
16:38:30 [                  main  471]  Reading https://occweb.cfa.harvard.edu/twiki/bin/view/ThermalWG/MeetingNotes twiki page
                                        Reading https://occweb.cfa.harvard.edu/twiki/bin/view/ThermalWG/MeetingNotes2019x12x10 twiki page
                                        Writing to /proj/sot/ska3/flight/data/twiki-wg/twg_index.html
                                        Reading https://occweb.cfa.harvard.edu/twiki/bin/view/ThermalWG/MeetingNotes2020x01x07 twiki page
                                        
16:38:30 [                  main  457]  Running '/bin/cp -p /proj/sot/ska3/flight/data/twiki-wg/ssawg_index.html /data/mta4/www/ASPECT/twiki-wg/' 0 1
16:38:30 [                  main  470]  twiki-wg output:
16:38:30 [                  main  471]  
16:38:30 [                  main  457]  Running '/bin/cp -p /proj/sot/ska3/flight/data/twiki-wg/mpcwg_index.html /data/mta4/www/ASPECT/twiki-wg/' 0 1
16:38:30 [                  main  470]  twiki-wg output:
16:38:30 [                  main  471]  
16:38:30 [                  main  457]  Running '/bin/cp -p /proj/sot/ska3/flight/data/twiki-wg/twg_index.html /data/mta4/www/ASPECT/twiki-wg/' 0 1
16:38:30 [                  main  470]  twiki-wg output:
16:38:30 [                  main  471]  
16:38:30 [   ./task_schedule3.pl  272]  
16:38:30 [                  main  457]  Running 'watch_cron_logs3.pl -email -printerror -erase -config /tmp/CGq7vLkzXE' 0 1
16:38:31 [                  main  470]  watch_cron_logs output:
16:38:31 [                  main  471]  
```
