### PR TITLE
Allow task_schedule config in Python package

### DIFF
--- a/task_schedule3.pl
+++ b/task_schedule3.pl
@@ -85,7 +85,6 @@ if ($opt{package}) {
     my $cfg_path = qx{python -c 'import ${pkg}, pathlib; print(pathlib.Path(${pkg}.__file__).parent)'};
     chomp($cfg_path);
     $opt{config} = "$cfg_path/$opt{config}";
-    print "Using config file $opt{config}\n";
 }
 # If config <path> is not an absolute path then look for config
 # in $SKA_ARCH_OS/share/<path>.  This is the preferred convention

--- a/task_schedule3.pl
+++ b/task_schedule3.pl
@@ -575,13 +575,15 @@ task_schedule.pl -config <config_file> [options]
 =over 8
 
 =item B<-package <package_name>>
+
 Name of the Python package in which the config file is located. This will set
 the root directory for the config file to site-packages/<package_name> in the
 Python library. More specifically, the code will import the package to discover
 the package top-level __file__ and use that to infer the config file location.
 
 =item B<-config <config_file>>
-This option gives the name of a file containing the task scheduler configuration
+
+This option gives the name of a file containing the task schedule configuration
 (default="task_schedule.cfg")  This file specifies the jobs to be
 run, email addresses for alerts, and all other program options.
 The test config file (t/data/test.config) has further documentation.


### PR DESCRIPTION
## Description

This fixes https://github.com/sot/skare3/issues/893 by adding a new `-package` option that allows specifying the name of the package. In this case the root directory where the `-config` file is relative to is the root of the installed package in `site-packages`.

This also makes `-config` be optional so that one could simply do `task_schedule.pl -package kalman_watch` and it will find the `task_schedule.cfg` in the `kalman_watch` package directory.

The current practice of installing task schedule config files outside of the package in `$CONDA_PREFIX/share/package_name` is deprecated and maybe no longer possible with the latest setuptools. See:
https://setuptools.pypa.io/en/latest/userguide/datafiles.html#non-package-data-files

## Testing

- [x] Passes unit tests on linux (`make test` appeared to work).

###  Functional testing

Installed this in a testing Ska3 2022.7 environment and used this in dev cron job for https://github.com/sot/kalman_watch/pull/6.
```
/export/tom/miniconda3/envs/ska3/bin/skare task_schedule3.pl -package kalman_watch
```

Fixes https://github.com/sot/skare3/issues/893