### PR TITLE
Document and test escaping @ in exec

### DIFF
--- a/t/bin/task1.pl
+++ b/t/bin/task1.pl
@@ -1,7 +1,8 @@
 #!/usr/bin/env perl
 
 my $sleep = shift @ARGV || 5;
+my $arg = shift @ARGV || "default";
 
-print "Hello from task1 $sleep at " . localtime()."\n";
+print "Hello from task1 $sleep $arg at " . localtime()."\n";
 sleep $sleep;
-print "Hello from task1 $sleep at " . localtime()." after sleep\n";
+print "Hello from task1 $sleep $arg at " . localtime()." after sleep\n";

--- a/t/data/basic/basic.config
+++ b/t/data/basic/basic.config
@@ -37,7 +37,7 @@ bin_dir      $ENV{SKA}/bin           # Bin dir (optional, see task def'n)
       cron       * * * * *
       check_cron = 0-59/2 * * * *
       exec 1 : task1.pl 1
-      exec 1 : $ENV{SKA}/bin/task1.pl 2
+      exec 1 : $ENV{SKA}/bin/task1.pl 2 user\@cfa.harvard.edu
       timeout 100
       context 1
       <checkk>

--- a/task_schedule3.pl
+++ b/task_schedule3.pl
@@ -697,6 +697,7 @@ The example config file below illustrates all the available configuration option
  #        Defaults to '0 0 * * *'.
  #  exec: Name of executable.  Can have $ENV{} vars which get interpolated.
  #        If bin_dir is defined then bin_dir is prepended to non-absolute exec names.
+#        Emails need to have the @ escaped as shown below.
  #  log: Name of log.  Can have $ENV{} vars which get interpolated.
  #        If log is set to '' then no log file will be created (not recommended)
  #        If log is not defined it is set to <task_name>.log.
@@ -720,7 +721,7 @@ The example config file below illustrates all the available configuration option
   <task task1>
         cron       * * * * *
         check_cron 0 1 * * *
-        exec task1.pl 20
+        exec task1.pl 20 aca\@cfa.harvard.edu
         timeout 15
         <check>
            <error>


### PR DESCRIPTION
## Description

This does not change any actual code, but updates documentation and testing to demonstrate that escaping `@` as `\@` in an exec string now works. This contradicts https://github.com/sot/task_schedule/issues/14#issuecomment-508163009. It may well be possible that the upstream `Safe` package that does the `reval` has been improved in the mean time.

Fixes #14

## Testing

- [x] Passes unit tests on MacOS (`make test_basic`)
- [x] Functional testing

### Functional testing

I did a hot-update of the dev version of FSS-check to include (roughly) `--email=user\@cfa.harvard.edu` and this correctly sent email to the list.